### PR TITLE
メッセージの自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,8 @@
 $(function() {
+  let message_body = $('.main-chat__body');
+
   function buildHTML(message) {
-    let html = `<div class="main-chat__message-items">
+    let html = `<div class="main-chat__message-items" data-message-id="${message.id}">
                   <div class="main-chat__message-items__message-header">
                     <p class="main-chat__message-items__user-name">${message.user_name}</p>
                     <p class="main-chat__message-items__date">${message.created_at}</p>
@@ -13,6 +15,26 @@ $(function() {
     }
     html += `</div>`;
     return html;
+  }
+
+  let reloadMessages = function() {
+    let last_message_id = $('.main-chat__message-items:last').data('message-id');
+    $.ajax({
+      type: 'GET',
+      url: 'api/messages',
+      dataType: 'json',
+      data: {id: last_message_id}
+    }).done(function(messages) {
+      if (messages.length == 0) return;
+      let html = ``;
+      messages.forEach(function(message) {
+        html += buildHTML(message);
+      });
+      message_body.append(html);
+      message_body.animate({scrollTop: message_body[0].scrollHeight});
+    }).fail(function() {
+      alert('error');
+    });
   }
 
   $("#new_message").on("submit", function(e) {
@@ -28,12 +50,15 @@ $(function() {
       contentType: false
     }).done(function(data) {
       let html = buildHTML(data);
-      $(".main-chat__body").append(html);
-      $(".main-chat__body").animate({scrollTop: $(".main-chat__body")[0].scrollHeight});
+      message_body.append(html);
+      message_body.animate({scrollTop: message_body[0].scrollHeight});
       $("form")[0].reset();
       $(".main-chat__form-items__send-btn").prop("disabled", false);
     }).fail(function() {
       alert("メッセージ送信に失敗しました");
     });
   });
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.where('id > ?', last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content    message.content
+  json.image      message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name  message.user.name
+  json.id         message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.main-chat__message-items
+.main-chat__message-items{data: {message: {id: message.id}}}
   .main-chat__message-items__message-header
     %p.main-chat__message-items__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.content    @message.content
 json.image      @message.image_url
 json.user_name  @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.id         @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: [:index], defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
- チャットメッセージをブラウザのリロードなしで自動更新するようにした
- 重複部分のコードを若干リファクタリング

# Why
- 機能追加のため
- 保守性向上のため

![3b25ec909ecf2d37289b36a5fec04149](https://user-images.githubusercontent.com/50756490/75109393-cda43d80-5665-11ea-9df9-f2a527f97220.gif)
